### PR TITLE
feat: GeoScore 2.5.0 Site Pass (do not deploy yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 .env
 .env.local
 .env.*
+server/data/
 
 # Test output
 *.log

--- a/docs/site-pass-external-backend.md
+++ b/docs/site-pass-external-backend.md
@@ -1,0 +1,38 @@
+# Site Pass external backend (no Worker, no browser admin)
+
+Fulfillment is server-to-server. Customers still pay in a browser. You do not need Dashboard clicks, Playwright, or a Cloudflare Worker to unlock a pass.
+
+## Already collecting money
+
+Live Payment Link on `acct_1U4zQQRg3Xb3gxxt`:
+
+https://buy.stripe.com/7sY28t61t9OE3WA9ah38400
+
+- Product: `geoscore_site_pass`
+- Price: `price_1UAACYRg3Xb3gxxtFoApW9iv` HKD 49
+- Required custom field: `domain`
+- Success: `https://geo.sayori.org/?pass=1&session_id={CHECKOUT_SESSION_ID}`
+
+Money can land without a backend. Automatic pass unlock cannot.
+
+## Recommended shape
+
+Payment Link -> Stripe Checkout -> webhook `checkout.session.completed` -> your server `POST /api/site-pass/webhook` -> JSON/SQLite -> frontend claim/status.
+
+Run:
+
+```
+node server/site-pass-server.mjs
+```
+
+Node 18+, no extra npm packages. Default store: `server/data/site-passes.json`.
+
+When you have a public URL:
+
+1. Stripe Dashboard -> Developers -> Webhooks -> `https://YOUR_HOST/api/site-pass/webhook`
+2. Event: `checkout.session.completed` only
+3. Put `whsec_...` and a restricted key in env
+
+Restricted key: Checkout Sessions read. Add write only if you use `POST /api/site-pass/checkout`.
+
+Do not deploy the Worker until this host is chosen. Do not use GMC account `acct_1U7pDyJUBi9fO7CM`.

--- a/docs/site-pass.md
+++ b/docs/site-pass.md
@@ -1,0 +1,49 @@
+# GeoScore 2.5.0 Site Pass
+
+Not deployed. Branch: `feature/site-pass`.
+
+## Stripe (already live)
+
+- Account: `acct_1U4zQQRg3Xb3gxxt` (self-controlled, not the GMC account)
+- Product: `geoscore_site_pass`
+- Price: `price_1UAACYRg3Xb3gxxtFoApW9iv` · HK$49
+- Payment Link: https://buy.stripe.com/7sY28t61t9OE3WA9ah38400
+- Success URL: `https://geo.sayori.org/?pass=1&session_id={CHECKOUT_SESSION_ID}`
+
+## What a pass includes
+
+One domain, 30 days:
+
+- full repair pack
+- shareable / printable report
+- 3 re-audits
+
+No ranking promise. No hands-on edits.
+
+## Routes (Worker or standalone server)
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/site-pass/webhook` | Stripe event, no browser |
+| GET | `/api/site-pass?domain=` | Is this domain paid? |
+| POST | `/api/site-pass/checkout` | Create Checkout Session from backend |
+| POST | `/api/site-pass/claim` | Exchange `session_id` after redirect |
+| POST | `/api/site-pass/rerun` | Consume one re-audit |
+
+## Two backends, same API
+
+1. Cloudflare Worker: `src/routes/site-pass.ts` + D1 `migrations/0006_site_passes.sql`
+2. Your own server: `server/site-pass-server.mjs` — see `docs/site-pass-external-backend.md`
+
+Do not deploy the Worker until you pick one and the webhook is pointed at it.
+
+## Secrets — do not commit
+
+Worker:
+
+```
+npx wrangler secret put STRIPE_SECRET_KEY --config wrangler.generated.jsonc
+npx wrangler secret put STRIPE_WEBHOOK_SECRET --config wrangler.generated.jsonc
+```
+
+Standalone server: export the same names. Restricted key only.

--- a/frontend/site-pass.js
+++ b/frontend/site-pass.js
@@ -1,0 +1,89 @@
+(function (global) {
+  'use strict';
+
+  const PAY_URL = 'https://buy.stripe.com/7sY28t61t9OE3WA9ah38400';
+  const API = (typeof global.SITE_PASS_API === 'string' && global.SITE_PASS_API)
+    ? global.SITE_PASS_API
+    : ((typeof global.PRODUCTION_API === 'string' && global.PRODUCTION_API)
+      ? global.PRODUCTION_API
+      : 'https://geo-api.sayori.org');
+
+  function currentDomain(auditData) {
+    return String(auditData?.domain || auditData?.root_domain || '')
+      .trim()
+      .replace(/^www\./, '')
+      .toLowerCase();
+  }
+
+  function cardEls() {
+    return {
+      card: global.document.getElementById('site-pass-card'),
+      body: global.document.getElementById('site-pass-body'),
+      buy: global.document.getElementById('site-pass-buy'),
+    };
+  }
+
+  async function status(domain) {
+    const res = await fetch(`${API}/api/site-pass?domain=${encodeURIComponent(domain)}`);
+    if (!res.ok) return { active: false };
+    return res.json();
+  }
+
+  async function claimFromQuery() {
+    const params = new URLSearchParams(global.location.search);
+    const sessionId = params.get('session_id');
+    if (!sessionId || params.get('pass') !== '1') return null;
+    const res = await fetch(`${API}/api/site-pass/claim`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: sessionId }),
+    });
+    if (!res.ok) return null;
+    return res.json();
+  }
+
+  function renderPass(pass, fallbackDomain) {
+    const els = cardEls();
+    if (!els.card) return;
+    els.card.classList.remove('hidden');
+    if (pass?.active) {
+      const date = new Date(pass.expires_at * 1000).toLocaleDateString();
+      els.body.textContent = `Pass active until ${date}. ${pass.reruns_remaining} re-audits left for ${pass.domain}.`;
+      if (els.buy) els.buy.classList.add('hidden');
+    } else if (els.buy) {
+      els.buy.classList.remove('hidden');
+      els.buy.setAttribute('href', PAY_URL);
+      els.buy.dataset.domain = fallbackDomain || '';
+    }
+  }
+
+  async function onAudit(data) {
+    const domain = currentDomain(data);
+    if (!domain) return;
+    const els = cardEls();
+    if (els.card) els.card.classList.remove('hidden');
+    try {
+      const claimed = await claimFromQuery();
+      if (claimed?.active) {
+        renderPass(claimed, domain);
+        return;
+      }
+      renderPass(await status(domain), domain);
+    } catch {
+      renderPass({ active: false }, domain);
+    }
+  }
+
+  global.GeoScoreSitePass = { PAY_URL, currentDomain, status, claimFromQuery, onAudit };
+
+  global.document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(global.location.search);
+    if (params.get('pass') === '1') {
+      const els = cardEls();
+      if (els.card) els.card.classList.remove('hidden');
+      claimFromQuery().then((pass) => {
+        if (pass) renderPass(pass, pass.domain);
+      }).catch(() => {});
+    }
+  });
+})(window);

--- a/migrations/0006_site_passes.sql
+++ b/migrations/0006_site_passes.sql
@@ -1,0 +1,26 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS site_passes (
+  id TEXT PRIMARY KEY,
+  domain TEXT NOT NULL,
+  email TEXT,
+  stripe_session_id TEXT NOT NULL UNIQUE,
+  stripe_payment_intent TEXT,
+  stripe_customer_id TEXT,
+  price_id TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  currency TEXT NOT NULL,
+  starts_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reruns_total INTEGER NOT NULL DEFAULT 3,
+  reruns_used INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'expired', 'refunded')),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_site_passes_domain_expires
+  ON site_passes(domain, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_site_passes_session
+  ON site_passes(stripe_session_id);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayori-geoscore",
-  "version": "2.4.7",
+  "version": "2.5.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://geo.sayori.org",
@@ -28,7 +28,8 @@
     "deploy:ui-worker:no-routes": "node scripts/deploy-no-routes.mjs wrangler.ui.jsonc",
     "db:migrate": "wrangler d1 migrations apply sayori-geoscore-db --remote --config wrangler.generated.jsonc",
     "db:migrate:local": "wrangler d1 migrations apply sayori-geoscore-db --local --config wrangler.jsonc",
-    "deploy:pages": "npm run build:css && wrangler pages deploy frontend --project-name=sayori-geoscore --branch main"
+    "deploy:pages": "npm run build:css && wrangler pages deploy frontend --project-name=sayori-geoscore --branch main",
+    "site-pass:server": "node server/site-pass-server.mjs"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250510.0",

--- a/server/env.example
+++ b/server/env.example
@@ -1,0 +1,12 @@
+# Copy to server/.env or export in systemd. Do not commit real keys.
+STRIPE_SECRET_KEY=rk_live_or_sk_live_restricted
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+STRIPE_PRICE_ID=price_1UAACYRg3Xb3gxxtFoApW9iv
+PORT=8788
+HOST=0.0.0.0
+SITE_PASS_STORE=./server/data/site-passes.json
+ALLOWED_ORIGINS=https://geo.sayori.org,https://sayori-geoscore.pages.dev
+SUCCESS_URL=https://geo.sayori.org/?pass=1&session_id={CHECKOUT_SESSION_ID}
+CANCEL_URL=https://geo.sayori.org/
+PASS_DURATION_DAYS=30
+PASS_RERUNS=3

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,8 @@ export interface Env {
   RESEND_API_KEY?: string;
   CF_TEMP_MAIL_BASE_URL?: string;
   CF_TEMP_MAIL_SEND_API_KEY?: string;
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
 }
 
 export type FixPackLanguage = 'en' | 'zh';

--- a/tests/release-metadata.test.mjs
+++ b/tests/release-metadata.test.mjs
@@ -13,7 +13,7 @@ test('standalone release metadata is public MIT with upstream attribution', () =
   const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
   const deployWorkflow = fs.readFileSync(path.join(root, '.github', 'workflows', 'deploy.yml'), 'utf8');
 
-  assert.equal(pkg.version, '2.4.7');
+  assert.equal(pkg.version, '2.5.0');
   assert.equal(pkg.private, false);
   assert.equal(pkg.license, 'MIT');
   assert.equal(pkg.repository?.url, 'git+https://github.com/Amiyadesi/geoscore.git');


### PR DESCRIPTION
## Status
Draft only. Do **not** merge or deploy until the payment webhook host is chosen.

## Already live on Stripe (acct_1U4zQQRg3Xb3gxxt)
- Product `geoscore_site_pass`
- Price `price_1UAACYRg3Xb3gxxtFoApW9iv` · HKD 49
- Payment Link https://buy.stripe.com/7sY28t61t9OE3WA9ah38400
- Success URL `https://geo.sayori.org/?pass=1&session_id={CHECKOUT_SESSION_ID}`

## In this branch so far
- `package.json` 2.5.0 + `site-pass:server` script
- D1 migration `migrations/0006_site_passes.sql`
- Frontend helper `frontend/site-pass.js`
- Env types for `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`
- Docs in `docs/site-pass.md`

## Follow-up commits still landing on this branch
- `src/routes/site-pass.ts` Worker handler
- `server/site-pass-server.mjs` standalone Node backend (no Cloudflare, no browser)
- Worker `src/index.ts` route wiring
- Report card in `frontend/index.html` / i18n / app hook

## Backend choice
Use the standalone Node server on the existing machine **or** the Worker. Same API. Webhook event: `checkout.session.completed` only.
